### PR TITLE
Added parameter `includeShortDesc` to `getAllTags` method.

### DIFF
--- a/SmartApp.KB/bindings/python/commands.py
+++ b/SmartApp.KB/bindings/python/commands.py
@@ -12,6 +12,7 @@ elif (sys.argv[1] == "removerule"): r = kb.removeRule(sys.argv[2], json.loads(sy
 elif (sys.argv[1] == "updatefact"): r = kb.updateFactByID(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6], json.loads(sys.argv[7]))
 elif (sys.argv[1] == "registertags"): r = kb.registerTags(sys.argv[2], json.loads(sys.argv[3]))
 elif (sys.argv[1] == "tagdetails"): r = kb.getTagDetails(sys.argv[2:])
+elif (sys.argv[1] == "getalltags"): r = kb.getAllTags(len(sys.argv) >= 3 and sys.argv[2].lower() in ["true", "yes", "y"])
 elif (sys.argv[1] == "register"): r = kb.register()
 else: 
     r = "invalid argument"

--- a/SmartApp.KB/bindings/python/kb.py
+++ b/SmartApp.KB/bindings/python/kb.py
@@ -60,6 +60,9 @@ class KnowledgeBaseClient():
 	def getTagDetails(self, tagsList: list):
 		return self.remote_call("getTagDetails", {"tagsList": tagsList})
 
+	def getAllTags(self, includeShortDesc):
+		return self.remote_call("getAllTags", {"includeShortDesc": includeShortDesc})
+
 	def addFact(self, idSource: str, tag: str, TTL: int, reliability: int, jsonFact: map):
 		return self.remote_call("addFact", {"idSource": idSource, "tag":tag, "TTL": TTL, "reliability": reliability, "jsonFact": jsonFact} )
 

--- a/SmartApp.KB/src/kb.ts
+++ b/SmartApp.KB/src/kb.ts
@@ -136,12 +136,12 @@ export class TagInfo {
     }
 }
 
-export function getAllTags() {
+export function getAllTags(includeShortDesc: boolean) {
     const allTags: any = {};
     for (const [user, tags] of userTags.entries()) {
         const tagsArray: any = {};
         for (const [tag, tagInfo] of tags.entries()) {
-            tagsArray[tag] = tagInfo;
+            tagsArray[tag] = includeShortDesc ? tagInfo.desc : null;
         }
         allTags[user] = tagsArray;
     }

--- a/SmartApp.KB/src/server.ts
+++ b/SmartApp.KB/src/server.ts
@@ -30,7 +30,7 @@ wss.on('connection', (ws: WebSocket) => {
 
             switch (j.method) {
                 case 'getAllTags':
-                    reply = JSON.stringify(kb.getAllTags());
+                    reply = JSON.stringify(kb.getAllTags(j.params.includeShortDesc));
                     break;
                 case 'register':
                     reply = JSON.stringify(kb.register());

--- a/SmartApp.KB/test/kb/test1.ts
+++ b/SmartApp.KB/test/kb/test1.ts
@@ -41,9 +41,9 @@ describe('registerTags', () => {
 
 describe('getAllTags', () => {
     it('should return all registered tags and corresponding user', () => {
-        const response = kb.getAllTags();
-        const expected = { 'id0' : {tag1 : {desc: 'desc1', doc: 'doc1'}, tag2: {desc: 'desc2', doc: 'doc2'}, 
-        tag3 : {desc: 'desc3', doc: 'doc3'}, tag4 : {desc: 'desc4', doc: 'doc4'}, tag6: {desc: 'desc6', doc: 'doc6'}}}
+        const response = kb.getAllTags(true);
+        const expected = { 'id0' : {tag1 : 'desc1', tag2: 'desc2',
+        tag3: 'desc3', tag4 : 'desc4', tag6: 'desc6' }};
         const expectedResponse = new kb.Response(true, expected);
         expect(response).to.deep.equal(expectedResponse);
     });


### PR DESCRIPTION
This pull request adds an additional parameter `includeShortDesc` to the `getAllTags` method.
When it is `false`, only the tag names are returned, and when it's `true` only the short description, not the full documentation, is added to the result.
The full documentation is rarely needed for an operation like `getAllTags`, and the user can always use `getTagDetails` to retrive the missing data.